### PR TITLE
fix: correct way to check permissions for all databases

### DIFF
--- a/admin/src/components/CollectionTypes/ExportCollectionsFile.js
+++ b/admin/src/components/CollectionTypes/ExportCollectionsFile.js
@@ -4,7 +4,7 @@ import { request } from 'strapi-helper-plugin';
 import { Button } from '@buffetjs/core';
 
 import CardWidget from '../data-display/CardWidget';
-import Notice from '../Feedback/Notice';
+import Notice from '../feedback/Notice';
 import Box from '../layout/Box';
 
 import downloadNamedJson from '../../utils/downloadNamedJson';

--- a/controllers/spm-file-export-content.js
+++ b/controllers/spm-file-export-content.js
@@ -26,7 +26,7 @@ module.exports = {
     // To track progress/contribute/submit a PR
     // visit this github link: https://github.com/ijsto/strapi-plugin-migrate/issues/6
     const { user } = ctx.state;
-    if (!user.roles || user.roles[0].id !== 1) {
+    if (!user.roles || user.roles[0].code !== 'strapi-super-admin') {
       return ctx.unauthorized('You must be an admin to export content.');
     }
 

--- a/controllers/spm-file-export-core-store.js
+++ b/controllers/spm-file-export-core-store.js
@@ -23,7 +23,6 @@ module.exports = {
   },
   getCoreStoreJSON: async ctx => {
     const { user } = ctx.state;
-    // Administrator role ID by default is 1, so we check for admin rights.
     if (user.roles[0].code !== 'strapi-super-admin') {
       return ctx.unauthorized('You must be an admin to export permissions.');
     }

--- a/controllers/spm-file-export-core-store.js
+++ b/controllers/spm-file-export-core-store.js
@@ -24,7 +24,7 @@ module.exports = {
   getCoreStoreJSON: async ctx => {
     const { user } = ctx.state;
     // Administrator role ID by default is 1, so we check for admin rights.
-    if (user.roles[0].id !== 1) {
+    if (user.roles[0].code !== 'strapi-super-admin') {
       return ctx.unauthorized('You must be an admin to export permissions.');
     }
 

--- a/controllers/spm-file-export-permissions.js
+++ b/controllers/spm-file-export-permissions.js
@@ -23,7 +23,7 @@ module.exports = {
   },
   getPermissions: async ctx => {
     const { user } = ctx.state;
-    if (user.roles[0].id !== 1) {
+    if (user.roles[0].code !== 'strapi-super-admin') {
       return ctx.unauthorized('You must be an admin to export permissions.');
     }
     
@@ -59,7 +59,7 @@ module.exports = {
   getPermissionsJSON: async ctx => {
     const { user } = ctx.state;
     // Administrator role ID by default is 1, so we check for admin rights.
-    if (user.roles[0].id !== 1) {
+    if (user.roles[0].code !== 'strapi-super-admin') {
       return ctx.unauthorized('You must be an admin to export permissions.');
     }
 

--- a/controllers/spm-file-export-permissions.js
+++ b/controllers/spm-file-export-permissions.js
@@ -58,7 +58,6 @@ module.exports = {
   },
   getPermissionsJSON: async ctx => {
     const { user } = ctx.state;
-    // Administrator role ID by default is 1, so we check for admin rights.
     if (user.roles[0].code !== 'strapi-super-admin') {
       return ctx.unauthorized('You must be an admin to export permissions.');
     }

--- a/controllers/spm-file-import-content.js
+++ b/controllers/spm-file-import-content.js
@@ -26,7 +26,7 @@ module.exports = {
     // To track progress/contribute/submit a PR
     // visit this github link: https://github.com/ijsto/strapi-plugin-migrate/issues/6
     const { user } = ctx.state;
-    if (user.roles[0].id != 1) {
+    if (user.roles[0].code !== 'strapi-super-admin') {
       return ctx.unauthorized('You must be an admin to import content.');
     }
 

--- a/controllers/spm-file-import-permissions.js
+++ b/controllers/spm-file-import-permissions.js
@@ -35,7 +35,7 @@ module.exports = {
   },
   uploadPermissionsJSON: async ctx => {
     const { user } = ctx.state;
-    if (user.roles[0].id != 1) {
+    if (user.roles[0].code !== 'strapi-super-admin') {
       return ctx.unauthorized('You must be an admin to import permissions.');
     }
     


### PR DESCRIPTION
When a user tries to open the plugin page in the dashboard he always redirects to the login page when MongoDB used as the database. This happens because MongoDB has a key as ObjectID and all checks for the admin role fail.