### PR TITLE
Feature: selective export of layouts

### DIFF
--- a/admin/src/components/CoreStore/ExportCoreStoreFile.js
+++ b/admin/src/components/CoreStore/ExportCoreStoreFile.js
@@ -23,10 +23,12 @@ export const ExportCoreStoreButton = ({ fileName, label, showOptions }) => {
     async function fetchData() {
       const { data } = await request('/content-type-builder/content-types');
       setModels(
-        data.map((model) => ({
-          value: model.uid,
-          name: model.schema.name,
-        }))
+        data
+          .map((model) => ({
+            value: model.uid,
+            name: model.schema.name,
+          }))
+          .sort((a, b) => a.name.localeCompare(b.name))
       );
     }
 
@@ -70,7 +72,7 @@ export const ExportCoreStoreButton = ({ fileName, label, showOptions }) => {
       {showOptions && (
         <Padded top size="smd">
           <select onChange={handleChange} disabled={!models}>
-            <option value="">All data</option>
+            <option value="">All models</option>
             {models && models.map(({ name, value }) => (
               <option key={value} value={value}>{name}</option>
             ))}

--- a/config/routes.json
+++ b/config/routes.json
@@ -34,7 +34,7 @@
     },
     {
       "method": "GET",
-      "path": "/getCoreStoreJSON",
+      "path": "/getCoreStoreJSON/:model?",
       "handler": "spm-file-export-core-store.getCoreStoreJSON",
       "config": {
         "policies": []

--- a/controllers/spm-file-export-core-store.js
+++ b/controllers/spm-file-export-core-store.js
@@ -23,12 +23,20 @@ module.exports = {
   },
   getCoreStoreJSON: async ctx => {
     const { user } = ctx.state;
+    const { model } = ctx.params;
+
     if (user.roles[0].code !== 'strapi-super-admin') {
-      return ctx.unauthorized('You must be an admin to export permissions.');
+      return ctx.unauthorized('You must be an admin to export settings and layouts.');
+    }
+
+    const queryOptions = { _limit: -1 };
+    if (model) {
+      const prefix = 'plugin_content_manager_configuration_content_types::';
+      queryOptions.key = prefix + model;
     }
 
     const coreStoreAPI = strapi.query('core_store');
-    const coreStore = await coreStoreAPI.find({ _limit: -1 });
+    const coreStore = await coreStoreAPI.find(queryOptions);
     const withoutIds = coreStore.map(({id, ...coreStoreNoIds}) => coreStoreNoIds)
 
     return withoutIds;


### PR DESCRIPTION
This will undoubtedly need me to do some tidying-up to match the current standards, but I figured it was worthwhile as a starting point to make this as a PR so we can discuss it.

Instead of exporting everything into one big file, we wanted to select individual models to export the layouts of, which is what this aims to do.

![image](https://user-images.githubusercontent.com/55830/113726675-5821f200-96ec-11eb-991e-f7bd6333a564.png)
